### PR TITLE
establish connection once

### DIFF
--- a/db/dbConnection.js
+++ b/db/dbConnection.js
@@ -1,35 +1,14 @@
 const mysql = require('mysql2')
 const config = require('./config.json')
 
-const openConnection = () => {
-    const connection = mysql.createConnection({
-        host: config.rds_host,
-        user: config.rds_username,
-        password: config.rds_password,
-        port: config.rds_port,
-        database: config.rds_db
-    });
-    connection.connect((err) => {
-        if (err) {
-            console.log(`Unable to connect to dbms: ${err}`)
-        } else {
-            console.log(`Successfully connected to dbms`)
-        }
-    });
-    return connection;
-}
-
-const closeConnection = (connection) => {
-    connection.end((err) => {
-        if (err) {
-            console.log(`Unable to disconnect from dbms: ${err}`)
-        } else {
-            console.log(`Successfully disconnected from dbms`)
-        }
-    });
-}
+const dbConnection = mysql.createPool({
+    host: config.rds_host,
+    user: config.rds_username,
+    password: config.rds_password,
+    port: config.rds_port,
+    database: config.rds_db
+});
 
 module.exports = {
-    openConnection,
-    closeConnection
+    dbConnection
 }

--- a/db/podsDb.js
+++ b/db/podsDb.js
@@ -1,27 +1,29 @@
-const {openConnection, closeConnection} = require("./dbConnection");
+const {dbConnection} = require("./dbConnection");
 
-/* 
+
+/*
   parameters: none
   returns: entire pods table on success, error message on error/when no pods exist
 */
 const getAllPods = async () => {
-  const connection = openConnection()
   return new Promise((resolve, reject) => {
     // Pods(pod_id, pod_name, visibility, creator_id, creation date, pod_code)
     const query = `
       SELECT * 
       FROM Pods 
     `;
-    
-    connection.query(query, (err, data) => {
-      if (err) {
-        reject(`Error in getAllPods: cannot get pods from Pods table. ${err.message}`);
-      } else if (data.length === 0) {
-        reject(`Error in getAllPods: no rows in the Pods table.`);
-      } else {
-        console.log(data)
-        resolve(data)
-      }
+
+    dbConnection.getConnection((err, connection) => {
+      connection.query(query, (err, data) => {
+        if (err) {
+          reject(`Error in getAllPods: cannot get pods from Pods table. ${err.message}`);
+        } else if (data.length === 0) {
+          reject(`Error in getAllPods: no rows in the Pods table.`);
+        } else {
+          console.log(data)
+          resolve(data)
+        }
+      });
     });
     // closeConnection(connection)
   });
@@ -32,7 +34,6 @@ const getAllPods = async () => {
   returns: all open public pod lifetime info on success, error message on error/when no pods exist
 */
 const explorePublicPods = async () => {
-  const connection = openConnection()
   return new Promise((resolve, reject) => {
     // Pods(pod_id, pod_name, visibility, creator_id, creation date, pod_code, pod_size)
     // Pod_Lifetimes(lifetime_id, start_date, pod_id, end_date, recurrence_rate, contribution_amount)
@@ -48,18 +49,19 @@ const explorePublicPods = async () => {
         WHERE start_date IS NULL) AS pod_lifetimes_table
         ON pods_table.pod_id = pod_lifetimes_table.pod_id
     `;
-    
-    connection.query(query, [PUBLIC_VISIBILITY_STRING], (err, data) => {
-      if (err) {
-        reject(`Error in explorePublicPods: cannot get public pods. ${err.message}`);
-      } else if (data.length === 0) {
-        reject(`Error in explorePublicPods: no rows in the result.`);
-      } else {
-        console.log(data)
-        resolve(data)
-      }
+
+    dbConnection.getConnection((err, connection) => {
+      connection.query(query, [PUBLIC_VISIBILITY_STRING], (err, data) => {
+        if (err) {
+          reject(`Error in explorePublicPods: cannot get public pods. ${err.message}`);
+        } else if (data.length === 0) {
+          reject(`Error in explorePublicPods: no rows in the result.`);
+        } else {
+          console.log(data)
+          resolve(data)
+        }
+      });
     });
-    // closeConnection(connection)
   });
 };
 
@@ -68,7 +70,6 @@ const explorePublicPods = async () => {
   returns: row in Pods table on success, error message on error
 */
 const getPod = async (pod_id) => {
-  const connection = openConnection()
   return new Promise((resolve, reject) => {
     // Pods(pod_id, pod_name, visibility, creator_id, creation date, pod_code)
     const query = `
@@ -76,15 +77,17 @@ const getPod = async (pod_id) => {
       FROM Pods 
       WHERE pod_id = ?
     `;
-    
-    connection.query(query, [pod_id], (err, data) => {
-      if (err) {
-        reject(`Error in getPod: cannot get pod from Pods table. ${err.message}`);
-      } else if (data.length === 0) {
-        reject(`Error in getPod: no rows in the Pods table matched pod_id: ${pod_id}.`);
-      } else {
-        resolve(data[0])
-      }
+
+    dbConnection.getConnection((err, connection) => {
+      connection.query(query, [pod_id], (err, data) => {
+        if (err) {
+          reject(`Error in getPod: cannot get pod from Pods table. ${err.message}`);
+        } else if (data.length === 0) {
+          reject(`Error in getPod: no rows in the Pods table matched pod_id: ${pod_id}.`);
+        } else {
+          resolve(data[0])
+        }
+      });
     });
     // closeConnection(connection)
   });
@@ -95,7 +98,6 @@ const getPod = async (pod_id) => {
   returns: row in Pods table on success, error message on error
 */
 const getPodsByName = async (pod_name) => {
-  const connection = openConnection()
   return new Promise((resolve, reject) => {
     // Pods(pod_id, pod_name, visibility, creator_id, creation date, pod_code)
     const query = `
@@ -107,16 +109,17 @@ const getPodsByName = async (pod_name) => {
     GROUP BY pods_lifetimes.pod_id;
     `;
     const pod_name_new = '%' + pod_name + '%';
-    connection.query(query, [pod_name_new], (err, data) => {
-      if (err) {
-        reject(`Error in getPodsByName: cannot get pod from Pods table. ${err.message}`);
-      } else if (data.length === 0) {
-        reject(`Error in getPodsByName: no rows in the Pods table matched pod_name: ${pod_name}.`);
-      } else {
-        resolve(data)
-      }
+    dbConnection.getConnection((err, connection) => {
+      connection.query(query, [pod_name_new], (err, data) => {
+        if (err) {
+          reject(`Error in getPodsByName: cannot get pod from Pods table. ${err.message}`);
+        } else if (data.length === 0) {
+          reject(`Error in getPodsByName: no rows in the Pods table matched pod_name: ${pod_name}.`);
+        } else {
+          resolve(data)
+        }
+      });
     });
-    // closeConnection(connection)
   });
 };
 
@@ -126,23 +129,23 @@ const getPodsByName = async (pod_name) => {
   returns: 1 on success, error message on error
 */
 const addPod = async(pod_id, name, visibility, creator_id, creation_date, pod_code, pod_size) => {
-  const connection = openConnection()
   return new Promise((resolve, reject) => {
     // Pods(pod_id, pod_name, visibility, creator_id, creation date, pod_code)
     const query = `
     INSERT INTO Pods (pod_id, pod_name, visibility, creator_id, creation_date, pod_code, pod_size) 
     VALUES (?, ?, ?, ?, ?, ?, ?)
     `
-    connection.query(query, [pod_id, name, visibility, creator_id, creation_date, pod_code, pod_size], (err, result) => {
-      if (err) {
-        reject(`Error in addPod: cannot add pod to Pods table. ${err.message}`);
-      } else if (result.affectedRows === 0) {
-        reject(`Error in addPod: no rows were modified when adding pod to Pods table. Pod might already exist`);
-      } else {
-        resolve(result.affectedRows) // should return 1 on success
-      }
+    dbConnection.getConnection((err, connection) => {
+      connection.query(query, [pod_id, name, visibility, creator_id, creation_date, pod_code, pod_size], (err, result) => {
+        if (err) {
+          reject(`Error in addPod: cannot add pod to Pods table. ${err.message}`);
+        } else if (result.affectedRows === 0) {
+          reject(`Error in addPod: no rows were modified when adding pod to Pods table. Pod might already exist`);
+        } else {
+          resolve(result.affectedRows) // should return 1 on success
+        }
+      });
     });
-    // closeConnection(connection)
   });
 }
 


### PR DESCRIPTION
is this an ok way to just establish a connection once? i tried with the debugger and it runs the "mysql.createPool()" thing in dbConnection.js just once, only when i start the app (it doesn't call it anymore when i call a route). only did the changes for pods for now so that you get the idea but if this is ok we'd need to do this for all db files